### PR TITLE
feat(cosmos-operator-rpc-node): port local git chart changes

### DIFF
--- a/charts/cosmos-operator-rpc-node/README.md
+++ b/charts/cosmos-operator-rpc-node/README.md
@@ -1,0 +1,44 @@
+# RPC node Helm Chart
+
+A Helm chart for deploying cosmos-sdk based RPC node.
+The chart utilizes [the Kubernetes cosmos-operator](https://github.com/strangelove-ventures/cosmos-operator).
+
+## Overview
+
+This chart deploys a complete RPC node including:
+
+- CosmosFullNode (cosmos-operator's CRD)
+- Ingress with configrable endpoints (RPC, gRPC, API, WS, etc)
+- Optional prometheus monitoring for:
+  - Default CometBFT metrics
+  - Latest block height compared to a given public RPC endpoint
+  - Endpoint monitoring for the deployed RPC endpoint
+
+## Prerequisites
+
+- Helm 3.2.0+
+- Cosmos-operator
+- Ingress Controller (nginx)
+- Cert-manager (optional, for TLS)
+- Prometheus blackbox exporter (optional, for monitoring)
+- Prometheus json exporter (optional, for monitoring)
+
+## Installation
+
+
+1. Customize the values file as needed or create a new one, and install the chart (note that the node name will be taken from the helm release name)
+
+```bash
+helm install <release-name> . \
+  --create-namespace \
+  --namespace <namespace> \
+  -f <values-file>
+```
+
+## Contributing
+
+[Contributing guidelines](CONTRIBUTING.md)
+
+## License
+
+Apache 2.0

--- a/charts/cosmos-operator-rpc-node/templates/NOTES.txt
+++ b/charts/cosmos-operator-rpc-node/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Your HTTP Basic Auth credentials have been automatically generated.
+
+Username: {{ randAlphaNum 8 }}
+Password: {{ randAlphaNum 16 }}
+
+These have been stored in the {{ .Release.Name }}-basic-auth-creds Kubernetes Secret.
+
+You can find them by running:
+
+kubectl -n {{ .Release.Namespace }} get secret {{ .Release.Name }}-basic-auth-creds -o jsonpath="{.data}" | jq -r 'to_entries[] | "\(.key): \(.value | @base64d)"'

--- a/charts/cosmos-operator-rpc-node/templates/_helpers.tpl
+++ b/charts/cosmos-operator-rpc-node/templates/_helpers.tpl
@@ -4,8 +4,8 @@
 {{- if (index $context.Values.endpoints $endpointName).host }}
 {{- printf "%s" (index $context.Values.endpoints $endpointName).host }}
 {{- else if eq $endpointName "rpc" }}
-{{- printf "%s-%s.%s" $context.Release.Name $context.Values.blch.nodeType "tm.p2p.org" }}
+{{- printf "%s-%s.%s" $context.Release.Name $context.Values.blch.nodeType $context.Values.endpointsBaseDomain }}
 {{- else }}
-{{- printf "%s-%s-%s.%s" $context.Release.Name $context.Values.blch.nodeType $endpointName "tm.p2p.org" }}
+{{- printf "%s-%s-%s.%s" $context.Release.Name $context.Values.blch.nodeType $endpointName $context.Values.endpointsBaseDomain }}
 {{- end -}}
 {{- end -}}

--- a/charts/cosmos-operator-rpc-node/templates/basic-auth-secret.yaml
+++ b/charts/cosmos-operator-rpc-node/templates/basic-auth-secret.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.basicAuth.enabled }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-basic-auth-creds" .Release.Name) }}
+{{- if not $existingSecret }}
+{{- $username := randAlphaNum 8 }}
+{{- $password := randAlphaNum 16 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-basic-auth-creds
+  annotations:
+    "helm.sh/hook": pre-upgrade, pre-install
+    "argocd.argoproj.io/hook": PreSync
+    "argocd.argoproj.io/hook-delete-policy": HookFailed
+type: Opaque
+data:
+  username: {{ $username | b64enc | quote }}
+  password: {{ $password | b64enc | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-basic-auth
+  annotations:
+    "helm.sh/hook": pre-upgrade, pre-install
+    "argocd.argoproj.io/hook": PreSync
+    "argocd.argoproj.io/hook-delete-policy": HookFailed  
+type: Opaque
+data:
+  auth: {{ htpasswd $username $password | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/cosmos-operator-rpc-node/templates/ingress-nlb.yaml
+++ b/charts/cosmos-operator-rpc-node/templates/ingress-nlb.yaml
@@ -8,23 +8,38 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ default $name $val.ingressName }}-nlb
-  {{- if $val.additionalIngressAnnotations }}
   annotations:
-    {{ toYaml $val.additionalIngressAnnotations | nindent 4 }}  
-  {{- end }}
+    {{ toYaml $val.additionalIngressAnnotations | nindent 4 }}
+    {{- if $.Values.basicAuth.enabled }}
+    nginx.ingress.kubernetes.io/auth-type: "basic"
+    nginx.ingress.kubernetes.io/auth-secret: "{{ $.Release.Name }}-basic-auth"
+    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Login"
+    {{- end }}
 spec:
   ingressClassName: nginx-nlb
   rules:
     - host: {{ $host | quote }}
       http:
         paths:
+        {{- if kindIs "slice" $val.path }}
+        {{- range $val.path }}
+          - path: {{ .path }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $.Release.Name }}-rpc
+                port:
+                  number: {{ .servicePort }}
+        {{- end }}
+        {{- else }}
           - path: {{ default "/" $val.path }}
             pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $.Release.Name }}-rpc
                 port:
-                  number: {{ $val.servicePort }}              
+                  number: {{ $val.servicePort }}
+        {{- end }}
   tls:
   - hosts:
     - {{ default $host $val.tlsHost | quote }}

--- a/charts/cosmos-operator-rpc-node/templates/prometheus-rules.yaml
+++ b/charts/cosmos-operator-rpc-node/templates/prometheus-rules.yaml
@@ -11,32 +11,32 @@ spec:
   groups:
   - name: blockchain-alerts
     rules:
-    - record: chain_block_height_diff
-      expr: |
-        label_replace(chain_latest_block_height{cosmos_node="{{ .Release.Name }}", namespace="{{ .Release.Namespace }}"}, "cosmos_node", "$1", "pod", "") 
-          - on  (namespace) group_left(pod) 
-          cometbft_consensus_height{pod=~"{{ .Release.Name }}-.?", namespace="{{ .Release.Namespace }}"}
-      labels:
-        cosmos_node: "{{ .Release.Name }}"
-        namespace: "{{ .Release.Namespace }}"
     - alert: BlockHeightDifferenceGrowing
       expr: |
-        chain_block_height_diff{cosmos_node="{{ .Release.Name }}", namespace="{{ .Release.Namespace }}"} > {{ .Values.monitoring.alerts.growingBlockHeightDifference }}   
+        sum(chain_latest_block_height{cosmos_node="{{ .Release.Name }}", namespace="{{ .Release.Namespace }}", rpc_endpoint="{{ .Values.monitoring.publicRpcEndpoint }}"})
+          - sum(chain_latest_block_height{cosmos_node="{{ .Release.Name }}", namespace="{{ .Release.Namespace }}", rpc_endpoint="{{ include "host" (dict "context" $ "endpointName" "rpc") }}"})
+          > {{ .Values.monitoring.alerts.growingBlockHeightDifference }}
       for: 5m
       labels:
         severity: warning
+        namespace: {{ .Release.Namespace }}
+        pod: {{ .Release.Name }}
       annotations:
-        summary: "Block height difference is growing for chain {{ .Values.blch.id }}"
-        description: "{{ .Release.Name }} node for chain {{ .Values.blch.id }} in namespace {{ .Values.namespace }} is more than {{ .Values.monitoring.alerts.growingBlockHeightDifference }} blocks behind the public RPC endpoint."        
+        summary: "Block height difference is growing for {{ .Release.Namespace }}/{{ .Release.Name }}"
+        description: "{{ .Release.Name }} node in namespace {{ .Release.Namespace }} is more than {{ .Values.monitoring.alerts.growingBlockHeightDifference }} blocks behind the public RPC endpoint."
     - alert: BlockHeightDifferenceCritical
       expr: |
-        chain_block_height_diff{cosmos_node="{{ .Release.Name }}", namespace="{{ .Release.Namespace }}"} > {{ .Values.monitoring.alerts.maximumBlockHeightDifference }}   
+        sum(chain_latest_block_height{cosmos_node="{{ .Release.Name }}", namespace="{{ .Release.Namespace }}", rpc_endpoint="{{ .Values.monitoring.publicRpcEndpoint }}"})
+          - sum(chain_latest_block_height{cosmos_node="{{ .Release.Name }}", namespace="{{ .Release.Namespace }}", rpc_endpoint="{{ include "host" (dict "context" $ "endpointName" "rpc") }}"})
+          > {{ .Values.monitoring.alerts.maximumBlockHeightDifference }}   
       for: 5m
       labels:
         severity: critical
+        namespace: {{ .Release.Namespace }}
+        pod: {{ .Release.Name }}                
       annotations:
-        summary: "Block height difference too high for chain {{ .Values.blch.id }}"
-        description: "{{ .Release.Name }} node for chain {{ .Values.blch.id }} in namespace {{ .Values.namespace }} is more than {{ .Values.monitoring.alerts.maximumBlockHeightDifference }} blocks behind the public RPC endpoint."
+        summary: "Block height difference too high for {{ .Release.Namespace }}/{{ .Release.Name }}"
+        description: "{{ .Release.Name }} node in namespace {{ .Release.Namespace }} is more than {{ .Values.monitoring.alerts.maximumBlockHeightDifference }} blocks behind the public RPC endpoint."
     - alert: CometBFTPeersDrop
       expr: |
         (cometbft_p2p_peers{pod=~"{{ .Release.Name }}-.*", namespace="{{ .Release.Namespace }}"} 
@@ -47,33 +47,21 @@ spec:
       labels:
         severity: info
       annotations:
-        summary: "CometBFT P2P Peers Drop for {{`$labels.chain_id`}}"
-        description: "The number of P2P peers for chain {{`$labels.chain_id`}} in {{`$labels.namespace`}}/{{`$labels.pod`}} has dropped by more than 25% over the last 5 minutes."
-    - alert: LowTxSuccessRate
-      expr: |
-        cometbft_consensus_total_txs{pod=~"{{ .Release.Name }}-.*", namespace="{{ .Release.Namespace }}"} 
-        - cometbft_mempool_failed_txs{pod=~"{{ .Release.Name }}-.*", namespace="{{ .Release.Namespace }}"} 
-          / cometbft_consensus_total_txs{pod=~"{{ .Release.Name }}-.*", namespace="{{ .Release.Namespace }}"}
-          * 100 < {{ .Values.monitoring.alerts.txSuccessRateThreshold }}
-      for: 5m
-      labels:
-        severity: warning
-      annotations:
-        summary: "High Failed TXs for {{`$labels.pod`}}"
-        description: "Transaction success rate is below the SLO for {{`$labels.chain_id`}} in {{`$labels.namespace`}} /{{`$labels.pod`}}."
-    - alert: RpcSvcDown
+        summary: "CometBFT P2P Peers Drop for {{ .Release.Name }} node in namespace {{ .Release.Namespace }}"
+        description: "The number of P2P peers for {{ .Release.Name }} node in namespace {{ .Release.Namespace }} has dropped by more than 25% over the last 5 minutes."
+    - alert: RpcEndpointDown
       expr: | 
         probe_http_status_code{
-        rpc_svc="{{ .Release.Name }}-rpc.{{ .Release.Namespace }}"} 
+        rpc_endpoint="{{ include "host" (dict "context" $ "endpointName" "rpc") }}"} 
           < 200 
           or 
-          probe_http_status_code{rpc_svc="{{ .Release.Name }}-rpc.{{ .Release.Namespace }}"}
+          probe_http_status_code{rpc_endpoint="{{ include "host" (dict "context" $ "endpointName" "rpc") }}"}
           >= 300
       for: 5m
       labels:
         severity: critical
       annotations:
-        summary: "The RPC svc for {{ .Release.Name }}-rpc.{{ .Release.Namespace }} is down."
-        description: "Service {{ .Release.Name }}-rpc in namespace {{ .Release.Namespace }} has been down for the last 5 minutes."
+        summary: "The RPC endpoint {{ include "host" (dict "context" $ "endpointName" "rpc") }} is down."
+        description: "Endpoint for {{ .Release.Name }} node in namespace {{ .Release.Namespace }} has been down for the last 5 minutes."
 {{- end -}}
 {{- end -}}

--- a/charts/cosmos-operator-rpc-node/templates/public-snapshot-ingress.yaml
+++ b/charts/cosmos-operator-rpc-node/templates/public-snapshot-ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.publishSnapshot.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-public-snapshot
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/rewrite-target: {{ .Values.publishSnapshot.pathPrefix }}/{{ .Values.blch.name }}/index.html
+    nginx.ingress.kubernetes.io/upstream-vhost: {{ .Values.publishSnapshot.baseDomain }}
+spec:
+  ingressClassName: nginx-nlb
+  rules:
+  - host: {{ .Values.blch.name }}-{{ .Values.blch.network }}-{{ .Values.blch.nodeType }}-snapshots.{{ .Values.endpointsBaseDomain }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Release.Name }}-public-snapshot
+            port:
+              number: 443
+  tls:
+  - hosts:
+    - {{ .Values.blch.name }}-{{ .Values.blch.network }}-{{ .Values.blch.nodeType }}-snapshots.{{ .Values.endpointsBaseDomain }}
+    secretName: {{ .Release.Name }}-public-snapshot-tls
+{{- end -}}

--- a/charts/cosmos-operator-rpc-node/templates/public-snapshot-sa.yaml
+++ b/charts/cosmos-operator-rpc-node/templates/public-snapshot-sa.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.publishSnapshot.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshots-bucket-{{ .Release.Name }}
+{{- end -}}

--- a/charts/cosmos-operator-rpc-node/templates/public-snapshot-svc.yaml
+++ b/charts/cosmos-operator-rpc-node/templates/public-snapshot-svc.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.publishSnapshot.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-public-snapshot
+spec:
+   type: ExternalName
+   externalName: {{ .Values.publishSnapshot.baseDomain }}
+   ports:
+     - port: 443
+       targetPort: 443
+{{- end -}}

--- a/charts/cosmos-operator-rpc-node/templates/rpc_node.yaml
+++ b/charts/cosmos-operator-rpc-node/templates/rpc_node.yaml
@@ -13,7 +13,12 @@ metadata:
   {{ end }}
 
 spec:
+  {{ if and (eq (int .Values.replicas) 1) .Values.rollingUpdateEnabled }}
+  # Only one replica will be running, the second replica will be disabled and used only during rolling updates
+  replicas: 2
+  {{ else}}
   replicas: {{ .Values.replicas }}
+  {{ end }}
   {{ if .Values.maxUnavailable }}
   strategy:
     maxUnavailable: {{ .Values.maxUnavailable }}
@@ -36,6 +41,13 @@ spec:
       overrides: |-
 {{ .Values.blch.appOverrides | nindent 8 }}
       {{- end }}
+    {{ if .Values.blch.dataDir }}
+    dataDir: {{ .Values.blch.dataDir }}
+    {{ end }}
+    {{ if .Values.blch.startCmd }}
+    startCmd:
+{{ toYaml .Values.blch.startCmd | nindent 6 }}
+    {{ end }}
     network: {{ .Values.blch.network }}
     chainID: {{ .Values.blch.id }}
     binary: {{ .Values.blch.binary }}
@@ -57,6 +69,12 @@ spec:
     {{ if .Values.blch.addrbookURL }}
     addrbookURL: {{ .Values.blch.addrbookURL }}
     {{ end }}
+    {{ if .Values.blch.snapshotScript }}
+    snapshotScript: {{ toYaml .Values.blch.snapshotScript | nindent 6 }}
+    {{ end }}
+    {{ if .Values.blch.genesisScript }}
+    genesisScript: {{ toYaml .Values.blch.genesisScript | nindent 6 }}
+    {{ end }}
     {{ if .Values.blch.config }}
     config:
       {{ if .Values.blch.config.seeds }}
@@ -77,8 +95,8 @@ spec:
     image: "{{ .Values.image }}:{{ .Values.imageTag }}"
     {{ if .Values.resources }}
     resources:
-      {{- toYaml .Values.resources | nindent 6 }}
-    {{- end }}
+      {{ toYaml .Values.resources | nindent 6 }}
+    {{ end }}
     {{ if .Values.nodeSelectorLabel }}
     nodeSelector:
       {{ toYaml .Values.nodeSelectorLabel | nindent 6 }}
@@ -122,10 +140,14 @@ spec:
     {{ if .Values.priorityClassName }}
     priorityClassName: {{ .Values.priorityClassName }}
     {{ end }}
-  {{ if .Values.additionalServiceConfig }}
   service:
-    {{ toYaml .Values.additionalServiceConfig | nindent 4 }}
+  {{ if .Values.additionalServiceConfig }}
+    {{ toYaml .Values.additionalServiceConfig | nindent 6 }}
   {{ end }}
+    {{ if .Values.service.publishSvcDuringSync }}
+    rpcTemplate:
+      publishNotReadyAddresses: true
+    {{ end }}
   volumeClaimTemplate:
     resources:
       requests:

--- a/charts/cosmos-operator-rpc-node/templates/service-monitor.yaml
+++ b/charts/cosmos-operator-rpc-node/templates/service-monitor.yaml
@@ -35,7 +35,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-block-height
+  name: {{ .Release.Name }}-external-latest-height
   labels:
     release: kube-prometheus-stack
 spec:
@@ -55,9 +55,6 @@ spec:
     scrapeTimeout: 10s
     metricRelabelings:
     - sourceLabels: []
-      targetLabel: chain_id
-      replacement: {{ .Values.blch.id }}
-    - sourceLabels: []
       targetLabel: namespace
       replacement: {{ .Release.Namespace }}
     - sourceLabels: []
@@ -66,6 +63,38 @@ spec:
     - sourceLabels: []
       targetLabel: rpc_endpoint
       replacement: {{ .Values.monitoring.publicRpcEndpoint }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-internal-latest-height
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-json-exporter
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+  - port: http
+    path: /probe
+    params:
+      module: [latest_block_height]
+      target: [https://{{ include "host" (dict "context" $ "endpointName" "rpc") }}/status]
+    interval: 30s
+    scrapeTimeout: 10s
+    metricRelabelings:
+    - sourceLabels: []
+      targetLabel: namespace
+      replacement: {{ .Release.Namespace }}
+    - sourceLabels: []
+      targetLabel: cosmos_node
+      replacement: {{ .Release.Name }}
+    - sourceLabels: []
+      targetLabel: rpc_endpoint
+      replacement: {{ include "host" (dict "context" $ "endpointName" "rpc") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -85,7 +114,7 @@ spec:
     path: /probe
     params:
       module: [http_2xx]
-      target: [{{ .Release.Name }}-rpc.{{ .Release.Namespace }}.svc.cluster.local:26657]
+      target: [https://{{ include "host" (dict "context" $ "endpointName" "rpc") }}]
     interval: 30s
     scrapeTimeout: 10s
     metricRelabelings:
@@ -93,6 +122,6 @@ spec:
       targetLabel: namespace
       replacement: {{ .Release.Namespace }}
     - sourceLabels: []
-      targetLabel: rpc_svc
-      replacement: {{ .Release.Name }}-rpc.{{ .Release.Namespace }}
-{{- end -}}
+      targetLabel: rpc_endpoint
+      replacement: {{ include "host" (dict "context" $ "endpointName" "rpc") }}
+{{- end }}

--- a/charts/cosmos-operator-rpc-node/values.yaml
+++ b/charts/cosmos-operator-rpc-node/values.yaml
@@ -1,82 +1,122 @@
 # Default values for RPC nodes
 
 ## Pod Specs
-image: "ghcr.io/p2p-org/cosmos-heighliner"
+image: ""
 imageTag: ""
-imagePullSecrets: "github-secret"
+imagePullSecrets: ""
 replicas: 1
 maxUnavailable: ""
 storage: ""
-storageClassName: "oci-bv"
-# Note: Key to be used for node affinity
+storageClassName: ""
+# Key to be used for node affinity
 nodeSelectorKey: ""
-# Note: [Optional] Additional matches for node affinity
-affinityAdditionalMatches: {}
-# Note: [Optional] Label to be used for node selector
-nodeSelectorLabel: {}
-# Note: [Optional] Enable podAntiAffinity to run only one pod per hostname
-podAntiAffinityPerNode: false
-volumeRetainPolicy: "Retain"
+# [Optional] Additional matches for node affinity
+# affinityAdditionalMatches: {}
+# [Optional] Label to be used for node selector
+# nodeSelectorLabel: {}
+# [Optional] Enable podAntiAffinity to run only one pod per hostname
+podAntiAffinityPerNode: true
+volumeRetainPolicy: "Delete"
+# Allow custom rollingUpdate strategy managed by CI/CD (Not part of this chart)
+rollingUpdateEnabled: false
 
-resources: {}
+# resources: {}
 
-# Note: Optional additional configuration for the pod template
-initContainers: {}
-cosmosNodeLabels: {}
-cosmosNodeAnnotations: {}
-priorityClassName: ""
+# Optional additional configuration for the pod template
+# initContainers: []
+# cosmosNodeLabels:
+#   app: "rpc-node"
+#   abc: "xyz"
+# cosmosNodeAnnotations: {}
+# priorityClassName
 
-# Note: Optional additional configuration for the services
 service:
-  maxP2PExternalAddresses: 1
-  p2pTemplate:
-    metadata:
-      labels: {}
-      annotations: {}
-    type: ClusterIP
+  # Allow endpoints to be available while pods are not ready during sync
+  publishSvcDuringSync: true
+# Optional additional configuration for the services
+# additionalServiceConfig:
+#   maxP2PExternalAddresses: 1
+#   p2pTemplate:
+#     metadata:
+#       labels:
+#         extra: labels
+#       annotations:
+#         extra: annotations
+#     type: NodePort
 
 ## Chain Specs
 blch:
-  # NOTE: Whether the node is a full or archive node. Options are "full" or "archive"
+  # Whether the node is a full or archive node. Options are "full" or "archive"
   nodeType: ""
   id: ""
   network: ""
+  name: ""
   binary: ""
   skipInvariants: true
-  # NOTE: Provide either a genesisURL or snapshotURL for the syncing process
-  genesisURL: ""
-  snapshotURL: ""
+  # Provide either a genesisURL or snapshotURL for the syncing process
+  # genesisURL: ""
+  # snapshotURL: ""
   minGasPrice: ""
-  appOverrides: ""
-  # NOTE: Specify an addr book url to download the peers from, if not available, you can add the peers under config.peers
-  addrbookURL: ""
-  # NOTE: Optional additional configuration for the network
-  config:
-    peers: ""
-    seeds: ""
-    overrides: ""
-  additionalStartArgs: ""
-  homeDir: ""
-  # Note: Optional pruning configuration, by default archive nodes are set to nothing, and full nodes are set to keep 100 recent blocks
-  pruning:
-    strategy: ""
-    interval: 0
-    keepEvery: 0
-    keepRecent: 0
+  # Optional additional configuration for the chain
+  # appOverrides: |-
+  #  [example]
+  #   key = "value"
 
-# Monitoring configuration
+  # Specify an addr book url to download the peers from, if not available, you can add the peers under config.peers
+  # addrbookURL: ""
+
+  # Optional additional configuration for the network
+  config:
+    # peers: ""
+    # seeds: ""
+    overrides: |-
+      [tx_index]
+      indexer = "kv"
+  # additionalStartArgs: ""
+  # homeDir: ""
+
+  # Optional pruning configuration, by default archive nodes are set to nothing, and full nodes are set to keep 100 recent blocks
+  # pruning:
+  #   strategy: "custom"
+  #   interval: 10
+  #   keepEvery: 0
+  #   keepRecent: 100
+
+# Requires kube-prometheus-stack to be installed, along with blackbox-exporter and prometheus-json-exporter. If not available, set to false.
+# JSON exporter is used to monitor the latest block height, and requires the following configuration during setup:
+#   ---
+#   modules:
+#     latest_block_height:
+#       metrics:
+#         - name: chain_latest_block_height
+#           path: '{.result.sync_info.latest_block_height}'
+#           valuetype: gauge  
 monitoring:
-  enabled: true
+  enabled: false
+  # Provide a public RPC endpoint to compare the block height with.
   publicRpcEndpoint: ""
   alerts:
-    enabled: true
+    enabled: false
     growingBlockHeightDifference: 25
     maximumBlockHeightDifference: 100
     maximumPeerDropPercentage: 25
-    txSuccessRateThreshold: 95
+
+# Optional configuration for hosting public snapshots. The snapshot solution is not part of this chart.
+publishSnapshot:
+  enabled: false
+  cronJobSchedule: "0 */12 * * *"
+  # The path prefix for the snapshots. By default the chain.name is also included in the path. For example, if the pathPrefix is set to "snapshots", the snapshots will be available under /snapshots/cosmoshub/. 
+  pathPrefix: ""
+
+# Basic Auth can be enabled  for all RPC endpoints, it will create a secret with a randomly generated username and password. Check NOTES.txt to retrieve the credentials.
+basicAuth:
+  enabled: false
+
+# All endpoints will be exposed under the same domain, you can set a base domain to be used for all endpoints. 
+endpointsBaseDomain: ""
 
 ## Ingress Specs
-# Note: Endpoints can be configured as a map, each representing an endpoint, you can define as many endpoints as needed, following the below structure:
+# Endpoints can be configured as a map, each representing an endpoint, you can define as many endpoints as needed, following the below structure:
 #   enabled: A boolean value to enable or disable the RPC service.
 #   servicePort: The port number for the RPC service. This is defined by the cosmos-operator and created as part of CosmosFullNode.
 #   path: (Optional) The path to set for the endpoints, default to `/` if not set.
@@ -88,47 +128,23 @@ monitoring:
 # Note that some endpoints might need additional overrides to work properly, you can define them as appOverrides under the blch specs.
 endpoints:
   rpc:
-    enabled: false
+    enabled: true
     servicePort: 26657
-    path: "/"
-    ingressName: ""
-    host: ""
-    tlsHost: ""
-    tlsSecretName: ""
     additionalIngressAnnotations: {}
   grpc:
     enabled: false
     servicePort: 9090
-    path: "/"
-    ingressName: ""
-    host: ""
-    tlsHost: ""
-    tlsSecretName: ""
     additionalIngressAnnotations: {}
   ws:
     enabled: false
     servicePort: 8546
-    path: "/"
-    ingressName: ""
-    host: ""
-    tlsHost: ""
-    tlsSecretName: ""
     additionalIngressAnnotations: {}
   ws-rpc:
     enabled: false
     servicePort: 26657
     path: "/websocket"
-    ingressName: ""
-    host: ""
-    tlsHost: ""
-    tlsSecretName: ""
     additionalIngressAnnotations: {}
   rest:
     enabled: false
     servicePort: 1317
-    path: "/"
-    ingressName: ""
-    host: ""
-    tlsHost: ""
-    tlsSecretName: ""
     additionalIngressAnnotations: {}


### PR DESCRIPTION
This PR moves the local git helm chart with its latest changes to the versioned chart here, and also moves any hard-coded P2P configurations to helm values.