### PR TITLE
chore: bump cosmos-exporter chart and app versions

### DIFF
--- a/charts/cosmos-exporter/Chart.yaml
+++ b/charts/cosmos-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cosmos-exporter
 description: A Helm chart for validator signatures verification in a specific cosmos network
 type: application
-version: 1.12.0
-appVersion: "1.1.6"
+version: 1.13.0
+appVersion: "1.1.7"

--- a/charts/cosmos-exporter/Chart.yaml
+++ b/charts/cosmos-exporter/Chart.yaml
@@ -3,4 +3,4 @@ name: cosmos-exporter
 description: A Helm chart for validator signatures verification in a specific cosmos network
 type: application
 version: 1.13.0
-appVersion: "1.1.7"
+appVersion: "1.1.8"

--- a/charts/cosmos-exporter/values.yaml
+++ b/charts/cosmos-exporter/values.yaml
@@ -6,7 +6,7 @@ port: &appPort 9100
 image:
   repository: ghcr.io/p2p-org/rcosmos-exporter
   pullPolicy: Always
-  tag: v1.1.7
+  tag: v1.1.8
 
 env:
   - name: PROMETHEUS_IP


### PR DESCRIPTION
The code updates the version and appVersion in the Chart.yaml file from 1.12.0 to 1.13.0 and from 1.1.6 to 1.1.7, respectively, and changes the image tag in values.yaml from v1.1.7 to v1.1.8.