### PR TITLE
feat(cosmos-exporter): add dynamic nodes generation for local node mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
           if [ -f ${{ matrix.chart_dir }}/Chart.yaml ]; then
             helm repo add bitnami https://charts.bitnami.com/bitnami
             helm repo add zalando https://opensource.zalando.com/postgres-operator/charts/postgres-operator
+            helm repo add p2p-cosmos https://p2p-org.github.io/cosmos-helm-charts/
             helm repo update
             helm dependency update ${{ matrix.chart_dir }}
             helm dependency build ${{ matrix.chart_dir }}

--- a/charts/blch-node/Chart.yaml
+++ b/charts/blch-node/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
   - name: cosmos-exporter
     version: 1.31.0
     repository: "https://p2p-org.github.io/cosmos-helm-charts/"
-    alias: cosmos-exporter
-    condition: cosmos-exporter.enabled
+    alias: cosmosExporter
+    condition: cosmosExporter.enabled

--- a/charts/blch-node/examples/values.yaml
+++ b/charts/blch-node/examples/values.yaml
@@ -258,3 +258,44 @@ endpoints:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
 
+# Cosmos Exporter configuration
+# Example 1: Generate local nodes using YAML anchor (recommended for dynamic node generation)
+# This automatically generates node configs from the headless provided K8s services based on replicas
+cosmos-exporter:
+  enabled: true
+  localNodes:
+    enabled: true
+    replicas: *replicas  # Uses YAML anchor to reference replicas value above
+  config:
+    general:
+      network: "cosmoshub-cosmos"
+      mode: "node"
+    node:
+      client: "gaiad"
+
+# Example 2: Static node configuration (traditional approach)
+# cosmos-exporter:
+#   enabled: true
+#   localNodes: false
+#   config:
+#     general:
+#       network: "cosmoshub-cosmos"
+#       mode: "node"
+#     nodes:
+#       rpc:
+#         - name: "node-0"
+#           url: "http://my-release-0:26657"
+#           healthEndpoint: "/health"
+#         - name: "node-1"
+#           url: "http://my-release-1:26657"
+#           healthEndpoint: "/health"
+#       lcd:
+#         - name: "node-0"
+#           url: "http://my-release-0:1317"
+#           healthEndpoint: "/cosmos/base/node/v1beta1/status"
+#         - name: "node-1"
+#           url: "http://my-release-1:1317"
+#           healthEndpoint: "/cosmos/base/node/v1beta1/status"
+#     node:
+#       client: "gaiad"
+

--- a/charts/blch-node/examples/values.yaml
+++ b/charts/blch-node/examples/values.yaml
@@ -261,7 +261,7 @@ endpoints:
 # Cosmos Exporter configuration
 # Example 1: Generate local nodes using YAML anchor (recommended for dynamic node generation)
 # This automatically generates node configs from the headless provided K8s services based on replicas
-cosmos-exporter:
+cosmosExporter:
   enabled: true
   localNodes:
     enabled: true
@@ -274,7 +274,7 @@ cosmos-exporter:
       client: "gaiad"
 
 # Example 2: Static node configuration (traditional approach)
-# cosmos-exporter:
+# cosmosExporter:
 #   enabled: true
 #   localNodes: false
 #   config:

--- a/charts/blch-node/templates/svc-headless.yaml
+++ b/charts/blch-node/templates/svc-headless.yaml
@@ -1,10 +1,10 @@
-{{- if eq .Values.blch.nodeType "sentry" }}
+{{- if eq .Values.blch.nodeType "sentry" || eq .Values.cosmosExporter.enabled true }}
 {{- range $i := until (int .Values.replicas) }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Release.Name }}-sentry-{{ $i }}
+  name: {{ $.Release.Name }}-headless-{{ $i }}
   labels:
 {{ include "blch-node.labels" $ | nindent 4 }}
 spec:
@@ -13,10 +13,13 @@ spec:
     app.kubernetes.io/name: {{ $.Release.Name }}
     statefulset.kubernetes.io/pod-name: {{ $.Release.Name }}-{{ $i }}
   ports:
+  {{ -if eq .Values.blch.nodeType "sentry" }}
     - protocol: TCP
       port: 1234
       targetPort: 1234
       name: p2p
+  {{ -end }}
+  {{ -if eq .Values.cosmosExporter.enabled true }}
     - protocol: TCP
       port: 26657
       targetPort: 26657
@@ -25,6 +28,7 @@ spec:
       port: 1317
       targetPort: 1317
       name: rest
+  {{ -end }}
   publishNotReadyAddresses: true
 {{- end }}
 {{- end }}

--- a/charts/blch-node/templates/svc-headless.yaml
+++ b/charts/blch-node/templates/svc-headless.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.blch.nodeType "sentry" || eq .Values.cosmosExporter.enabled true }}
+{{- if or (eq .Values.blch.nodeType "sentry") (and .Values.cosmosExporter.enabled .Values.cosmosExporter.localNodes.enabled) }}
 {{- range $i := until (int .Values.replicas) }}
 ---
 apiVersion: v1
@@ -13,13 +13,13 @@ spec:
     app.kubernetes.io/name: {{ $.Release.Name }}
     statefulset.kubernetes.io/pod-name: {{ $.Release.Name }}-{{ $i }}
   ports:
-  {{ -if eq .Values.blch.nodeType "sentry" }}
+  {{- if eq $.Values.blch.nodeType "sentry" }}
     - protocol: TCP
       port: 1234
       targetPort: 1234
       name: p2p
-  {{ -end }}
-  {{ -if eq .Values.cosmosExporter.enabled true }}
+  {{- end }}
+  {{- if and $.Values.cosmosExporter.enabled $.Values.cosmosExporter.localNodes.enabled }}
     - protocol: TCP
       port: 26657
       targetPort: 26657
@@ -28,7 +28,7 @@ spec:
       port: 1317
       targetPort: 1317
       name: rest
-  {{ -end }}
+  {{- end }}
   publishNotReadyAddresses: true
 {{- end }}
 {{- end }}

--- a/charts/blch-node/values.yaml
+++ b/charts/blch-node/values.yaml
@@ -276,6 +276,12 @@ endpoints:
 # Set enabled to false to disable the cosmos-exporter subchart
 cosmos-exporter:
   enabled: false
+  # Generate local node configurations from Kubernetes services
+  # When enabled, dynamically generates node configs from the provided headless K8s services
+  # Use YAML anchor to pass replicas: replicas: &replicas 3, then localNodes.replicas: *replicas
+  localNodes:
+    enabled: false
+    replicas: 0
   nodeSelector: {}
 #   image:
 #     repository: ghcr.io/p2p-org/rcosmos-exporter

--- a/charts/blch-node/values.yaml
+++ b/charts/blch-node/values.yaml
@@ -1,11 +1,11 @@
 # Default values for RPC nodes
 
 ## Pod Specs
-image: ""
-imageTag: ""
+image: "example-registry/image-name"
+imageTag: "tag"
 # Toolkit image used for init containers and healthcheck sidecar
-toolkitImage: ""
-toolkitImageTag: ""
+toolkitImage: "example-registry/image-name"
+toolkitImageTag: "tag"
 # Image pull policy for all containers (defaults to "Always" if not set)
 imagePullPolicy: "Always"
 imagePullSecrets: ""
@@ -274,7 +274,7 @@ endpoints:
 
 # Cosmos Exporter configuration
 # Set enabled to false to disable the cosmos-exporter subchart
-cosmos-exporter:
+cosmosExporter:
   enabled: false
   # Generate local node configurations from Kubernetes services
   # When enabled, dynamically generates node configs from the provided headless K8s services

--- a/charts/cosmos-exporter/templates/configmap.yaml
+++ b/charts/cosmos-exporter/templates/configmap.yaml
@@ -23,7 +23,13 @@ data:
         {{- end }}
       nodes:
         rpc:
-          {{- if and .Values.config.nodes.rpc (ne (len .Values.config.nodes.rpc) 0) }}
+          {{- if .Values.localNodes.enabled }}
+          {{- range $i := until (int .Values.localNodes.replicas) }}
+          - name: {{ $.Release.Name }}-{{ $i }}
+            url: http://{{ $.Release.Name }}-headless-{{ $i }}:26657
+            healthEndpoint: /health
+          {{- end }}
+          {{- else if and .Values.config.nodes.rpc (ne (len .Values.config.nodes.rpc) 0) }}
           {{- range .Values.config.nodes.rpc }}
           - name: {{ .name }}
             url: {{ .url }}
@@ -33,7 +39,13 @@ data:
           []
           {{- end }}
         lcd:
-          {{- if and .Values.config.nodes.lcd (ne (len .Values.config.nodes.lcd) 0) }}
+          {{- if .Values.localNodes.enabled }}
+          {{- range $i := until (int .Values.localNodes.replicas) }}
+          - name: {{ $.Release.Name }}-{{ $i }}
+            url: http://{{ $.Release.Name }}-headless-{{ $i }}:1317
+            healthEndpoint: /cosmos/base/node/v1beta1/status
+          {{- end }}
+          {{- else if and .Values.config.nodes.lcd (ne (len .Values.config.nodes.lcd) 0) }}
           {{- range .Values.config.nodes.lcd }}
           - name: {{ .name }}
             url: {{ .url }}

--- a/charts/cosmos-exporter/values.yaml
+++ b/charts/cosmos-exporter/values.yaml
@@ -182,3 +182,10 @@ affinity: {}
 tolerations: []
 
 nodeSelector: {}
+
+# Enable for node mode when full nodes are running and exposed as local Kubernetes services to generate rpc/lcd endpoints configs dynamically
+# Service names are expected to be in the format: <release-name>-headless-<node-index>
+localNodes:
+  enabled: false
+# Number of nodes
+  replicas: 0


### PR DESCRIPTION
Allow using local RPC/LCD endpoints in node mode when full-nodes are running and exposed as Kubernetes services 