### PR TITLE
feat: allow multiple releases of cosmos exporter charts

### DIFF
--- a/charts/blch-node/Chart.lock
+++ b/charts/blch-node/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: cosmos-exporter
-  repository: https://p2p-org.github.io/cosmos-helm-charts/
-  version: 1.33.2
-digest: sha256:1839ae23f3a5ba0f72e8fa2764f9d2d94dd7985bcb568082e7275180e70b1d23
-generated: "2025-12-17T18:11:38.681573+04:00"

--- a/charts/blch-node/Chart.yaml
+++ b/charts/blch-node/Chart.yaml
@@ -5,9 +5,3 @@ type: application
 version: 0.0.0-development
 appVersion: "1.0"
 
-dependencies:
-  - name: cosmos-exporter
-    version: 1.33.2
-    repository: "https://p2p-org.github.io/cosmos-helm-charts/"
-    alias: cosmos-exporter
-    condition: cosmos-exporter.enabled

--- a/charts/blch-node/files/scripts/chain-init.sh
+++ b/charts/blch-node/files/scripts/chain-init.sh
@@ -13,4 +13,6 @@ else
 fi
 
 echo "Initializing into tmp dir for downstream processing..."
+# cleanup old tmp in case it had leftovers
+rm -rf "$HOME/.tmp"
 $CHAIN_BINARY init --chain-id $CHAIN_ID $NODE_NAME --home "$HOME/.tmp"

--- a/charts/cosmos-exporter/templates/configmap.yaml
+++ b/charts/cosmos-exporter/templates/configmap.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cosmos-exporter.fullname" . }}-config
+  {{- if .Values.localNodeID }}
+    name: {{ include "cosmos-exporter.fullname" . }}-config-{{ .Values.localNodeID }}
+  {{- else }}
+    name: {{ include "cosmos-exporter.fullname" . }}-config
+  {{- end }}
   labels:
     {{- include "cosmos-exporter.labels" . | nindent 4 }}
 data:
@@ -22,40 +26,17 @@ data:
         {{- else }}
         validators: []
         {{- end }}
+     {{- with .Values.localNodeID }}
       nodes:
         rpc:
-          {{- if .Values.localNodes.enabled }}
-          {{- range $i := until (int .Values.localNodes.replicas) }}
-          - name: {{ $.Release.Name }}-{{ $i }}
-            url: http://{{ $.Release.Name }}-headless-{{ $i }}:26657
+          - name: {{ $.Release.Name }}-{{ . }}
+            url: http://{{ $.Release.Name }}-headless-{{ . }}:26657
             healthEndpoint: /status
-          {{- end }}
-          {{- else if and .Values.config.nodes.rpc (ne (len .Values.config.nodes.rpc) 0) }}
-          {{- range .Values.config.nodes.rpc }}
-          - name: {{ .name }}
-            url: {{ .url }}
-            healthEndpoint: {{ .healthEndpoint }}
-          {{- end }}
-          {{- else }}
-          []
-          {{- end }}
         lcd:
-          {{- if .Values.localNodes.enabled }}
-          {{- range $i := until (int .Values.localNodes.replicas) }}
-          - name: {{ $.Release.Name }}-{{ $i }}
-            url: http://{{ $.Release.Name }}-headless-{{ $i }}:1317
+          - name: {{ $.Release.Name }}-{{ . }}
+            url: http://{{ $.Release.Name }}-headless-{{ . }}:1317
             healthEndpoint: /cosmos/base/node/v1beta1/status
-          {{- end }}
-          {{- else if and .Values.config.nodes.lcd (ne (len .Values.config.nodes.lcd) 0) }}
-          {{- range .Values.config.nodes.lcd }}
-          - name: {{ .name }}
-            url: {{ .url }}
-            healthEndpoint: {{ .healthEndpoint }}
-          {{- end }}
-          {{- else }}
-          []
-          {{- end }}
-
+      {{- end }}
     node:
       client: {{ .Values.config.node.client }}
       tendermint:

--- a/charts/cosmos-exporter/templates/deployment.yaml
+++ b/charts/cosmos-exporter/templates/deployment.yaml
@@ -1,7 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cosmos-exporter.fullname"  . }}
+  {{- if .Values.localNodeID }}
+  name: {{ include "cosmos-exporter.fullname" . }}-{{ .Values.localNodeID }}
+  {{- else }}
+  name: {{ include "cosmos-exporter.fullname" . }}
+  {{- end }}
   labels:
     {{- include "cosmos-exporter.labels" . | nindent 4 }}
     {{- with .Values.metadata.labels }}
@@ -27,25 +31,20 @@ spec:
         - name: {{ include "cosmos-exporter.fullname"  . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.localNodes.enabled (gt (len .Values.env) 0) }}
           env:
-            {{- if .Values.localNodes.enabled }}
-            {{- range $i := until (int .Values.localNodes.replicas) }}
+            {{- with .Values.localNodeID }}
             - name: NODE_NAME
-              value: {{ $.Release.Name }}-{{ $i }}
-            {{- end }}
+              value: {{ $.Release.Name }}-{{ . }}
             {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- end }}
           {{- if .Values.externalSecrets }}
           envFrom:
             {{- range .Values.externalSecrets }}
             - secretRef:
                 name: {{ .target.name }}
             {{- end }}
-          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.port }}
@@ -81,6 +80,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if .Values.localNodeID }}
         - name: config
           configMap:
-            name: {{ include "cosmos-exporter.fullname" . }}-config
+            name: {{ include "cosmos-exporter.fullname" . }}-config-{{ .Values.localNodeID }}
+          {{- else }}
+          - name: config
+            configMap:
+              name: {{ include "cosmos-exporter.fullname" . }}-config
+          {{- end }}

--- a/charts/cosmos-exporter/templates/service.yaml
+++ b/charts/cosmos-exporter/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "cosmos-exporter.fullname"  . }}
+  {{- if .Values.localNodeID }}
+  name: {{ include "cosmos-exporter.fullname" . }}-{{ .Values.localNodeID }}
+  {{- else }}
+  name: {{ include "cosmos-exporter.fullname" . }}
+  {{- end }}
   labels:
     {{- include "cosmos-exporter.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
- Allow deploying releases of the cosmos exporter to support multiple replicas for node mode
- Remove cosmos-exporter dependency from blch-node