### PR TITLE
feat: support resources name overrides

### DIFF
--- a/charts/blch-node/templates/_helpers.tpl
+++ b/charts/blch-node/templates/_helpers.tpl
@@ -1,5 +1,19 @@
+{{/*
+Create a default fully qualified app name.
+Priority: 1) fullNameOverride, 2) .Release.Name if useShortenedChartName, 3) .Release.Name-.Chart.Name
+*/}}
+{{- define "blch-node.fullname" -}}
+{{- if .Values.fullNameOverride }}
+{{- .Values.fullNameOverride | trunc 63 | trimSuffix "-" }}
+{{- else if .Values.useShortenedChartName }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
 {{- define "blch-node.labels" -}}
-app.kubernetes.io/name: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "blch-node.fullname" . }}
 {{- $labels := .Values.labels }}
 {{- if not $labels }}
 {{- $labels = .Values.commonLabels }}
@@ -94,11 +108,12 @@ Endpoints configuration
 {{- define "host" -}}
 {{- $context := .context -}}
 {{- $endpointName := .endpointName -}}
+{{- $name := include "blch-node.fullname" $context }}
 {{- if (index $context.Values.endpoints $endpointName).host }}
 {{- printf "%s" (index $context.Values.endpoints $endpointName).host }}
 {{- else if eq $endpointName "rpc" }}
-{{- printf "%s-%s.%s" $context.Release.Name $context.Values.blch.nodeType $context.Values.endpointsBaseDomain }}
+{{- printf "%s-%s.%s" $name $context.Values.blch.nodeType $context.Values.endpointsBaseDomain }}
 {{- else }}
-{{- printf "%s-%s-%s.%s" $context.Release.Name $context.Values.blch.nodeType $endpointName $context.Values.endpointsBaseDomain }}
+{{- printf "%s-%s-%s.%s" $name $context.Values.blch.nodeType $endpointName $context.Values.endpointsBaseDomain }}
 {{- end -}}
 {{- end -}}

--- a/charts/blch-node/templates/basic-auth-secret.yaml
+++ b/charts/blch-node/templates/basic-auth-secret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.basicAuth.enabled }}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-basic-auth-creds" .Release.Name) }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-basic-auth-creds" (include "blch-node.fullname" .)) }}
 {{- if not $existingSecret }}
 {{- $username := randAlphaNum 8 }}
 {{- $password := randAlphaNum 16 }}
@@ -7,7 +7,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-basic-auth-creds
+  name: {{ include "blch-node.fullname" . }}-basic-auth-creds
   labels:
 {{ include "blch-node.labels" . | nindent 4 }}
   annotations:
@@ -22,7 +22,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-basic-auth
+  name: {{ include "blch-node.fullname" . }}-basic-auth
   labels:
 {{ include "blch-node.labels" . | nindent 4 }}
   annotations:

--- a/charts/blch-node/templates/configmap-scripts.yaml
+++ b/charts/blch-node/templates/configmap-scripts.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-scripts
+  name: {{ include "blch-node.fullname" . }}-scripts
   labels:
     {{- include "blch-node.labels" . | nindent 4 }}
 data:

--- a/charts/blch-node/templates/configmap.yaml
+++ b/charts/blch-node/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-config-overlay
+  name: {{ include "blch-node.fullname" . }}-config-overlay
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "blch-node.labels" . | nindent 4 }}
@@ -24,9 +24,9 @@ data:
     {{- end }}
   {{- if .Values.p2pDNSNameEnabled }}
   {{- range $i := until (int .Values.replicas) }}
-  config-overlay-defaults-{{ $.Release.Name }}-{{ $i }}.toml: |
+  config-overlay-defaults-{{ include "blch-node.fullname" $ }}-{{ $i }}.toml: |
     [p2p]
-    external_address = "{{ $.Release.Name }}-{{ $i }}.{{ $.Values.endpointsBaseDomain }}:26656"
+    external_address = "{{ include "blch-node.fullname" $ }}-{{ $i }}.{{ $.Values.endpointsBaseDomain }}:26656"
   {{- end }}
   {{- end }}
   {{- with .Values.configOverrides }}
@@ -36,7 +36,7 @@ data:
   {{- end }}
   {{- with .pernode }}
   {{- range . }}
-  config-overlay-overrides-{{ $.Release.Name }}-{{ .podOrdinal }}.toml: |
+  config-overlay-overrides-{{ include "blch-node.fullname" $ }}-{{ .podOrdinal }}.toml: |
     {{- .overrides | nindent 4 }}
   {{- end }}
   {{- end }}
@@ -58,7 +58,7 @@ data:
   {{- end }}
   {{- with .pernode }}
   {{- range . }}
-  app-overlay-overrides-{{ $.Release.Name }}-{{ .podOrdinal }}.toml: |
+  app-overlay-overrides-{{ include "blch-node.fullname" $ }}-{{ .podOrdinal }}.toml: |
     {{- .overrides | nindent 4 }}
   {{- end }}
   {{- end }}

--- a/charts/blch-node/templates/httproute.yaml
+++ b/charts/blch-node/templates/httproute.yaml
@@ -17,7 +17,7 @@
 {{- $servicePort = $.Values.service.ports.rpc.port }}
 {{- end }}
 {{- end }}
-{{- $name := printf "%s-%s" $.Release.Name $key }}
+{{- $name := printf "%s-%s" (include "blch-node.fullname" $) $key }}
 {{- $host := include "host" (dict "context" $ "endpointName" $key) }}
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -49,7 +49,7 @@ spec:
         type: PathPrefix
         value: {{ .path }}
     backendRefs:
-    - name: {{ $.Release.Name }}-rpc
+    - name: {{ include "blch-node.fullname" $ }}-rpc
       port: {{ default $servicePort .servicePort }}
       kind: Service
       weight: 1
@@ -60,7 +60,7 @@ spec:
         type: PathPrefix
         value: {{ default "/" $val.path }}
     backendRefs:
-    - name: {{ $.Release.Name }}-rpc
+    - name: {{ include "blch-node.fullname" $ }}-rpc
       group: ''
       port: {{ $servicePort }}
       kind: Service

--- a/charts/blch-node/templates/ingress.yaml
+++ b/charts/blch-node/templates/ingress.yaml
@@ -16,7 +16,7 @@
 {{- $servicePort = $.Values.service.ports.rpc.port }}
 {{- end }}
 {{- end }}
-{{- $name := printf "%s-%s" $.Release.Name $key }}
+{{- $name := printf "%s-%s" (include "blch-node.fullname" $) $key }}
 {{- $host := include "host" (dict "context" $ "endpointName" $key) }}
 {{- $tlsSecretName := printf "%s-%s" $host "tls" }}
 ---
@@ -33,7 +33,7 @@ metadata:
     {{- end }}
     {{- if $.Values.basicAuth.enabled }}
     nginx.ingress.kubernetes.io/auth-type: "basic"
-    nginx.ingress.kubernetes.io/auth-secret: "{{ $.Release.Name }}-basic-auth"
+    nginx.ingress.kubernetes.io/auth-secret: "{{ include "blch-node.fullname" $ }}-basic-auth"
     nginx.ingress.kubernetes.io/auth-realm: "Authentication Required - Login"
     {{- end }}
   {{- end }}
@@ -49,7 +49,7 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ $.Release.Name }}-rpc
+                name: {{ include "blch-node.fullname" $ }}-rpc
                 port:
                   number: {{ default $servicePort .servicePort }}
         {{- end }}
@@ -58,7 +58,7 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ $.Release.Name }}-rpc
+                name: {{ include "blch-node.fullname" $ }}-rpc
                 port:
                   number: {{ $servicePort }}
         {{- end }}

--- a/charts/blch-node/templates/pdb.yaml
+++ b/charts/blch-node/templates/pdb.yaml
@@ -3,12 +3,12 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .Release.Name }}-pdb
+  name: {{ include "blch-node.fullname" . }}-pdb
   labels:
 {{ include "blch-node.labels" . | nindent 4 }}
 spec:
   minAvailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "blch-node.fullname" . }}
 {{- end }}

--- a/charts/blch-node/templates/public-snapshot-httproute.yaml
+++ b/charts/blch-node/templates/public-snapshot-httproute.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
-  name: {{ .Release.Name }}-public-snapshot
+  name: {{ include "blch-node.fullname" . }}-public-snapshot
   labels:
   {{ include "blch-node.labels" . | nindent 4 }}
   annotations:
@@ -28,7 +28,7 @@ spec:
         type: PathPrefix
         value: /
     backendRefs:
-    - name: {{ .Release.Name }}-public-snapshot
+    - name: {{ include "blch-node.fullname" . }}-public-snapshot
       group: ''
       port: 443
       kind: Service

--- a/charts/blch-node/templates/public-snapshot-ingress.yaml
+++ b/charts/blch-node/templates/public-snapshot-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-public-snapshot
+  name: {{ include "blch-node.fullname" . }}-public-snapshot
   labels:
   {{ include "blch-node.labels" . | nindent 4 }}
   annotations:
@@ -20,11 +20,11 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ .Release.Name }}-public-snapshot
+            name: {{ include "blch-node.fullname" . }}-public-snapshot
             port:
               number: 443
   tls:
   - hosts:
     - {{ .Values.blch.name }}-{{ .Values.blch.network }}-{{ .Values.blch.nodeType }}-snapshots.{{ .Values.endpointsBaseDomain }}
-    secretName: {{ .Release.Name }}-public-snapshot-tls
+    secretName: {{ include "blch-node.fullname" . }}-public-snapshot-tls
 {{- end }}

--- a/charts/blch-node/templates/public-snapshot-sa.yaml
+++ b/charts/blch-node/templates/public-snapshot-sa.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: snapshots-bucket-{{ .Release.Name }}
+  name: snapshots-bucket-{{ include "blch-node.fullname" . }}
   labels:
   {{ include "blch-node.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/blch-node/templates/public-snapshot-svc.yaml
+++ b/charts/blch-node/templates/public-snapshot-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-public-snapshot
+  name: {{ include "blch-node.fullname" . }}-public-snapshot
   labels:
   {{ include "blch-node.labels" . | nindent 4 }}
 spec:

--- a/charts/blch-node/templates/service-monitor.yaml
+++ b/charts/blch-node/templates/service-monitor.yaml
@@ -3,12 +3,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-metrics
+  name: {{ include "blch-node.fullname" . }}-metrics
   labels:
 {{ include "blch-node.labels" . | nindent 4 }}
 spec:
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ include "blch-node.fullname" . }}
   ports:
     - name: metrics
       port: 26660
@@ -17,14 +17,14 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-sdk-metrics
+  name: {{ include "blch-node.fullname" . }}-sdk-metrics
   labels:
 {{ include "blch-node.labels" . | nindent 4 }}
     release: kube-prometheus-stack
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "blch-node.fullname" . }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
@@ -37,7 +37,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-external-latest-height
+  name: {{ include "blch-node.fullname" . }}-external-latest-height
   labels:
 {{ include "blch-node.labels" . | nindent 4 }}
     release: kube-prometheus-stack
@@ -62,7 +62,7 @@ spec:
       replacement: {{ .Release.Namespace }}
     - sourceLabels: []
       targetLabel: cosmos_node
-      replacement: {{ .Release.Name }}
+      replacement: {{ include "blch-node.fullname" . }}
     - sourceLabels: []
       targetLabel: rpc_endpoint
       replacement: {{ .Values.monitoring.publicRpcEndpoint }}
@@ -71,7 +71,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-internal-latest-height
+  name: {{ include "blch-node.fullname" . }}-internal-latest-height
   labels:
 {{ include "blch-node.labels" . | nindent 4 }}
     release: kube-prometheus-stack
@@ -96,7 +96,7 @@ spec:
       replacement: {{ .Release.Namespace }}
     - sourceLabels: []
       targetLabel: cosmos_node
-      replacement: {{ .Release.Name }}
+      replacement: {{ include "blch-node.fullname" . }}
     - sourceLabels: []
       targetLabel: rpc_endpoint
       replacement: {{ include "host" (dict "context" $ "endpointName" "rpc") }}
@@ -104,7 +104,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-rpc-endpoint
+  name: {{ include "blch-node.fullname" . }}-rpc-endpoint
   labels:
 {{ include "blch-node.labels" . | nindent 4 }}
     release: kube-prometheus-stack

--- a/charts/blch-node/templates/serviceaccount.yaml
+++ b/charts/blch-node/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "blch-node.fullname" . }}
   labels:
     {{- include "blch-node.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/blch-node/templates/statefulset.yaml
+++ b/charts/blch-node/templates/statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "blch-node.fullname" . }}
   labels:
     {{- include "blch-node.labels" . | nindent 4 }}
   {{- if .Values.nodeAnnotations  }}
@@ -10,7 +10,7 @@ metadata:
     {{- toYaml .Values.nodeAnnotations | nindent 4 }}
   {{- end }}
 spec:
-  serviceName: {{ .Release.Name }}-rpc
+  serviceName: {{ include "blch-node.fullname" . }}-rpc
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
@@ -25,9 +25,9 @@ spec:
         {{- end }}
         {{- if .Values.vaultInjection.enabled }}
         vault.hashicorp.com/agent-inject: "true"
-        vault.hashicorp.com/agent-inject-secret-{{ .Values.vaultInjection.secretKey }}: {{ .Values.global.vaultBasePath }}/{{ $.Release.Namespace }}/{{ .Release.Name }}/{{ .Values.vaultInjection.secretName }}
+        vault.hashicorp.com/agent-inject-secret-{{ .Values.vaultInjection.secretKey }}: {{ .Values.global.vaultBasePath }}/{{ $.Release.Namespace }}/{{ include "blch-node.fullname" . }}/{{ .Values.vaultInjection.secretName }}
         vault.hashicorp.com/agent-inject-template-{{ .Values.vaultInjection.secretKey }}: |
-          {{`{{- with secret "`}}{{ .Values.global.vaultBasePath }}/{{ .Release.Namespace }}/{{ .Release.Name }}/{{ .Values.vaultInjection.secretName }}{{`" }}
+          {{`{{- with secret "`}}{{ .Values.global.vaultBasePath }}/{{ .Release.Namespace }}/{{ include "blch-node.fullname" . }}/{{ .Values.vaultInjection.secretName }}{{`" }}
           {{ index .Data.data "`}}{{ .Values.vaultInjection.secretKey }}{{`" }}
           {{- end }}`}}
         vault.hashicorp.com/role: {{ .Values.global.vaultRole }}
@@ -40,7 +40,7 @@ spec:
         {{- include "blch-node.labels" . | nindent 8 }}
     spec:
       {{- if .Values.vaultInjection.enabled }}
-      serviceAccount: {{ .Release.Name }}
+      serviceAccount: {{ include "blch-node.fullname" . }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -328,14 +328,14 @@ spec:
               - key: app.kubernetes.io/name
                 operator: In
                 values:
-                - {{ .Release.Name }}
+                - {{ include "blch-node.fullname" . }}
             topologyKey: "kubernetes.io/hostname"
           - labelSelector:
               matchExpressions:
               - key: app.kubernetes.io/name
                 operator: In
                 values:
-                - {{ .Release.Name }}
+                - {{ include "blch-node.fullname" . }}
             topologyKey: "topology.kubernetes.io/zone"
       {{- end }}
         nodeAffinity:
@@ -364,7 +364,7 @@ spec:
         emptyDir: {}
       - name: vol-config
         configMap:
-          name: {{ .Release.Name }}-config-overlay
+          name: {{ include "blch-node.fullname" . }}-config-overlay
           defaultMode: 420
           items:
           - key: config-overlay-defaults.toml
@@ -373,8 +373,8 @@ spec:
             path: app-overlay-defaults.toml
           {{- if .Values.p2pDNSNameEnabled }}
           {{- range $i := until (int .Values.replicas) }}
-          - key: config-overlay-defaults-{{ $.Release.Name }}-{{ $i }}.toml
-            path: config-overlay-defaults-{{ $.Release.Name }}-{{ $i }}.toml
+          - key: config-overlay-defaults-{{ include "blch-node.fullname" $ }}-{{ $i }}.toml
+            path: config-overlay-defaults-{{ include "blch-node.fullname" $ }}-{{ $i }}.toml
           {{- end }}
           {{- end }}
           {{- with .Values.configOverrides }}
@@ -384,8 +384,8 @@ spec:
           {{- end }}
           {{- with .pernode }}
           {{- range . }}
-          - key: config-overlay-overrides-{{ $.Release.Name }}-{{ .podOrdinal }}.toml
-            path: config-overlay-overrides-{{ $.Release.Name }}-{{ .podOrdinal }}.toml
+          - key: config-overlay-overrides-{{ include "blch-node.fullname" $ }}-{{ .podOrdinal }}.toml
+            path: config-overlay-overrides-{{ include "blch-node.fullname" $ }}-{{ .podOrdinal }}.toml
           {{- end }}
           {{- end }}
           {{- end }}
@@ -396,14 +396,14 @@ spec:
           {{- end }}
           {{- with .pernode }}
           {{- range . }}
-          - key: app-overlay-overrides-{{ $.Release.Name }}-{{ .podOrdinal }}.toml
-            path: app-overlay-overrides-{{ $.Release.Name }}-{{ .podOrdinal }}.toml
+          - key: app-overlay-overrides-{{ include "blch-node.fullname" $ }}-{{ .podOrdinal }}.toml
+            path: app-overlay-overrides-{{ include "blch-node.fullname" $ }}-{{ .podOrdinal }}.toml
           {{- end }}
           {{- end }}
           {{- end }}
       - name: vol-scripts
         configMap:
-          name: {{ .Release.Name }}-scripts
+          name: {{ include "blch-node.fullname" . }}-scripts
           defaultMode: 0755
       {{- if .Values.sidecar.configMaps }}
       {{- range .Values.sidecar.configMaps }}

--- a/charts/blch-node/templates/svc-headless.yaml
+++ b/charts/blch-node/templates/svc-headless.yaml
@@ -5,14 +5,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Release.Name }}-headless-{{ $i }}
+  name: {{ include "blch-node.fullname" $ }}-headless-{{ $i }}
   labels:
 {{ include "blch-node.labels" $ | nindent 4 }}
 spec:
   clusterIP: None
   selector:
-    app.kubernetes.io/name: {{ $.Release.Name }}
-    statefulset.kubernetes.io/pod-name: {{ $.Release.Name }}-{{ $i }}
+    app.kubernetes.io/name: {{ include "blch-node.fullname" $ }}
+    statefulset.kubernetes.io/pod-name: {{ include "blch-node.fullname" $ }}-{{ $i }}
   ports:
   {{- if eq $.Values.blch.nodeType "sentry" }}
     - protocol: TCP

--- a/charts/blch-node/templates/svc.yaml
+++ b/charts/blch-node/templates/svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-rpc
+  name: {{ include "blch-node.fullname" . }}-rpc
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "blch-node.labels" . | nindent 4 }}
@@ -41,7 +41,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Release.Name }}-p2p-{{ $i }}
+  name: {{ include "blch-node.fullname" $ }}-p2p-{{ $i }}
   namespace: {{ $.Release.Namespace | quote }}
   labels:
     {{- include "blch-node.labels" $ | nindent 4 }}
@@ -54,7 +54,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- with $.Values.p2pDNSNameEnabled }}
-    external-dns.alpha.kubernetes.io/hostname: {{ $.Release.Name }}-{{ $i }}.{{ $.Values.endpointsBaseDomain }}
+    external-dns.alpha.kubernetes.io/hostname: {{ include "blch-node.fullname" $ }}-{{ $i }}.{{ $.Values.endpointsBaseDomain }}
   {{- end }}
   {{- end }}
 spec:
@@ -71,6 +71,6 @@ spec:
       targetPort: {{ $.Values.service.p2p.containerPort }}
       protocol: {{ $.Values.service.p2p.protocol }}
   selector:
-    app.kubernetes.io/name: {{ $.Release.Name }}
-    statefulset.kubernetes.io/pod-name: {{ $.Release.Name }}-{{ $i }}
+    app.kubernetes.io/name: {{ include "blch-node.fullname" $ }}
+    statefulset.kubernetes.io/pod-name: {{ include "blch-node.fullname" $ }}-{{ $i }}
 {{- end }}

--- a/charts/blch-node/values.yaml
+++ b/charts/blch-node/values.yaml
@@ -1,5 +1,12 @@
 # Default values for RPC nodes
 
+# Naming: resource names (StatefulSet, Services, ConfigMaps, etc.)
+# - Default: full chart name (Release.Name-Chart.Name), e.g. "myrelease-blch-node"
+# - useShortenedChartName: true → use only .Release.Name, e.g. "myrelease"
+# - fullNameOverride: "my-custom-name" → use this exact name (overrides the above)
+fullNameOverride: ""
+useShortenedChartName: false
+
 ## Pod Specs
 image: "example-registry/image-name"
 imageTag: "tag"

--- a/charts/cosmos-exporter/templates/configmap.yaml
+++ b/charts/cosmos-exporter/templates/configmap.yaml
@@ -25,12 +25,12 @@ data:
      {{- if ne (toString .Values.localNodeID) "" }}
       nodes:
         rpc:
-          - name: {{ $.Release.Name }}-{{ .Values.localNodeID }}
-            url: http://{{ $.Release.Name }}-headless-{{ .Values.localNodeID }}:26657
+          - name: {{ .Values.localNodeName | default $.Release.Name }}-{{ .Values.localNodeID }}
+            url: http://{{ .Values.localNodeName | default $.Release.Name }}-headless-{{ .Values.localNodeID }}:26657
             healthEndpoint: /status
         lcd:
-          - name: {{ $.Release.Name }}-{{ .Values.localNodeID }}
-            url: http://{{ $.Release.Name }}-headless-{{ .Values.localNodeID }}:1317
+          - name: {{ .Values.localNodeName | default $.Release.Name }}-{{ .Values.localNodeID }}
+            url: http://{{ .Values.localNodeName | default $.Release.Name }}-headless-{{ .Values.localNodeID }}:1317
             healthEndpoint: /cosmos/base/node/v1beta1/status
       {{- end }}
     node:

--- a/charts/cosmos-exporter/templates/deployment.yaml
+++ b/charts/cosmos-exporter/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           env:
             {{- if ne (toString .Values.localNodeID) "" }}
             - name: NODE_NAME
-              value: {{ $.Release.Name }}-{{ .Values.localNodeID }}
+              value: {{ .Values.localNodeName | default $.Release.Name }}-{{ .Values.localNodeID }}
             {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}

--- a/charts/cosmos-exporter/values.yaml
+++ b/charts/cosmos-exporter/values.yaml
@@ -201,5 +201,7 @@ nodeSelector: {}
 
 # For node mode when full nodes are running and exposed as local Kubernetes services to generate rpc/lcd endpoints configs dynamically
 # If localNodeID is not set, the endpoints will not be generated.
-# Service names are expected to be in the format: <release-name>-headless-<localNodeID>
+# Service names are expected to be in the format: <localNodeName or release-name>-headless-<localNodeID>
+# localNodeName: optional override for the base name; if not set, .Release.Name is used for node name and headless service lookup
+localNodeName: ""
 localNodeID: ""


### PR DESCRIPTION
- Allow the blch-node chart to use full chart name or an optional override, for use as subchart
- For backward compatibility, allow using shortened release-name only 
- Allow setting the node and service name accordingly for the cosmos-exporter chart