### PR TITLE
feat(blch-node): add support for additional service/container ports

### DIFF
--- a/charts/blch-node/templates/statefulset.yaml
+++ b/charts/blch-node/templates/statefulset.yaml
@@ -244,6 +244,11 @@ spec:
         - name: ws
           containerPort: {{ .Values.service.ports.ws.containerPort }}
           protocol: {{ .Values.service.ports.ws.protocol }}
+        {{- range .Values.service.ports.additional }}
+        - name: {{ .name }}
+          containerPort: {{ .containerPort | default .port }}
+          protocol: {{ .protocol | default "TCP" }}
+        {{- end }}
         volumeMounts:
         {{- include "blch-node.nodeContainerVolumeMounts" . | nindent 10 }}
       - name: healthcheck

--- a/charts/blch-node/templates/svc.yaml
+++ b/charts/blch-node/templates/svc.yaml
@@ -34,6 +34,12 @@ spec:
       port: {{ .Values.service.ports.ws.port }}
       targetPort: ws
       protocol: {{ .Values.service.ports.ws.protocol }}
+    {{- range .Values.service.ports.additional }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort | default .name }}
+      protocol: {{ .protocol | default "TCP" }}
+    {{- end }}
   selector:
     {{- include "blch-node.labels" . | nindent 4 }}
 {{ range $i := until (int .Values.replicas) }}

--- a/charts/blch-node/values.yaml
+++ b/charts/blch-node/values.yaml
@@ -181,6 +181,27 @@ service:
       port: 9091
       containerPort: 9091
       protocol: TCP
+    # [Optional] Additional ports to expose on the RPC Service and node container.
+    # Useful for EVM-style chains (Sei, Story, 0G, Cronos EVM) that expose JSON-RPC on
+    # ports outside the standard rpc/grpc/rest/ws set. Defaults to empty: existing
+    # networks render identically.
+    #
+    # Each entry supports:
+    #   name           (required) — port name, also used as targetPort if not set
+    #   port           (required) — Service port
+    #   containerPort  (optional) — defaults to .port
+    #   targetPort     (optional) — defaults to .name
+    #   protocol       (optional) — defaults to TCP
+    #
+    # To expose the port externally via Ingress/HTTPRoute, also add an entry under
+    # `endpoints` with `enabled: true` and `servicePort: <port>`.
+    #
+    # Example (Sei EVM HTTP JSON-RPC):
+    #   additional:
+    #     - name: evm-rpc
+    #       port: 8545
+    #       containerPort: 8545
+    additional: []
 # Optional additional configuration for the services
 # maxP2PExternalAddresses: 1
 # additionalServiceConfig:


### PR DESCRIPTION
Enables EVM-style chains (Sei, Story, 0G, Cronos EVM) to expose extra ports (e.g. JSON-RPC on 8545) without forking the chart. Existing networks render byte-identically since service.ports.additional defaults to an empty list.